### PR TITLE
[공통 컴포넌트] Tabs - 추가코드 제안

### DIFF
--- a/src/components/tabs/Tabs.styles.ts
+++ b/src/components/tabs/Tabs.styles.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-export const TabsContainer = styled.div`
+export const TabsContainer = styled.div<{ $autoWidth?: boolean }>`
   display: flex;
-  width: 100%;
+  width: ${(props) => (props.$autoWidth ? 'auto' : '100%')};
   gap: 0.5rem;
   overflow-x: auto;
 

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -6,12 +6,13 @@ import { TabsProps } from './Tabs.types';
  * @param tabs tabs string array
  * @param activeTab active tab string
  * @param onTabClick click event handler
+ * @param autoWidth optional prop to set width to auto
  * @returns {JSX.Element}
  */
 
-export default function Tabs({ tabs, activeTab, onTabClick }: TabsProps) {
+export default function Tabs({ tabs, activeTab, onTabClick, autoWidth = false }: TabsProps) {
   return (
-    <S.TabsContainer>
+    <S.TabsContainer $autoWidth={autoWidth}>
       {tabs.map((tab) => (
         <S.Tab key={tab} isActive={tab === activeTab} onClick={() => onTabClick(tab)}>
           <S.TabText isActive={tab === activeTab}>{tab}</S.TabText>

--- a/src/components/tabs/Tabs.types.ts
+++ b/src/components/tabs/Tabs.types.ts
@@ -6,4 +6,16 @@ export type TabsProps = {
   tabs: string[];
   activeTab: string;
   onTabClick: (tab: string) => void;
+
+  /**
+   * 넓이 조정 여부
+   * default: false
+   *
+   * false - width: 100%
+   *
+   * true - width: auto
+   *
+   * 중앙으로 정렬해서 쓰고 싶은 경우 true를 추천
+   */
+  autoWidth?: boolean;
 };


### PR DESCRIPTION
## 🔥 PR 제목  
#62 이슈에 자세히 적어놨습니다.
요약하자면 ```width: 100%```가 대부분 상황에 좋은데,
특정 상황(지도 페이지, tab개수가 적은 경우, 화면이 넓은 경우)에 불편한 상황이 있더라구요.
해결 방안으로 선택적 파라미터 추가한 거라 이미 사용한 분들에게도 오류가 발생하지 않을 것입니다!
## 📌 작업 내용  

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  
더 좋은 방법이 있다면 알려주세요!
## 🙏 리뷰어에게 한마디  