### PR TITLE
[공통컴포넌트] Tabs - 토글 기능(선택적) 추가 및 border 일관성

### DIFF
--- a/src/components/tabs/Tabs.styles.ts
+++ b/src/components/tabs/Tabs.styles.ts
@@ -25,10 +25,10 @@ export const Tab = styled.button<{ isActive: boolean }>`
   border-radius: 1.25rem;
   transition:
     background-color 0.3s ease,
-    border 0.3s ease;
+    border-color 0.3s ease;
   cursor: pointer;
-  border: ${(props) =>
-    props.isActive ? 'none' : `0.6px solid ${props.theme.colors.grayScale.white}`};
+  border: 0.6px solid;
+  border-color: ${(props) => (props.isActive ? 'transparent' : props.theme.colors.grayScale.white)};
   background-color: ${(props) =>
     props.isActive ? props.theme.colors.primary.bl400 : 'transparent'};
 

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -7,14 +7,29 @@ import { TabsProps } from './Tabs.types';
  * @param activeTab active tab string
  * @param onTabClick click event handler
  * @param autoWidth optional prop to set width to auto
+ * @param toggle optional prop to set toggle behavior
  * @returns {JSX.Element}
  */
 
-export default function Tabs({ tabs, activeTab, onTabClick, autoWidth = false }: TabsProps) {
+export default function Tabs({
+  tabs,
+  activeTab,
+  onTabClick,
+  autoWidth = false,
+  toggle = false,
+}: TabsProps) {
+  const handleTabClick = (tab: string) => {
+    if (toggle && activeTab === tab) {
+      onTabClick('');
+    } else {
+      onTabClick(tab);
+    }
+  };
+
   return (
     <S.TabsContainer $autoWidth={autoWidth}>
       {tabs.map((tab) => (
-        <S.Tab key={tab} isActive={tab === activeTab} onClick={() => onTabClick(tab)}>
+        <S.Tab key={tab} isActive={tab === activeTab} onClick={() => handleTabClick(tab)}>
           <S.TabText isActive={tab === activeTab}>{tab}</S.TabText>
         </S.Tab>
       ))}

--- a/src/components/tabs/Tabs.types.ts
+++ b/src/components/tabs/Tabs.types.ts
@@ -18,4 +18,10 @@ export type TabsProps = {
    * 중앙으로 정렬해서 쓰고 싶은 경우 true를 추천
    */
   autoWidth?: boolean;
+
+  /**
+   * 토글 가능 여부
+   * default: false
+   */
+  toggle?: boolean;
 };


### PR DESCRIPTION
## 🔥 PR 제목  
Tabs의 토글기능(선택적) 추가와 border 일관성 향상 제안
## 📌 작업 내용  
1. 토글(tab 활성화&비활성화) 기능이 필요하여 선택사항으로 기능 추가했습니다.
2. 기존에는 tab활성화 시 `border: none;` 되어 크기가 바뀌었습니다. 그래서 border size를 고정하고 투명해지는 방식으로 바꿔봤습니다.
## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  
선택사항 추가라, 기존의 사용하는 쪽 코드를 수정할 필요는 없습니다!