### PR TITLE
feat: color 버튼 구현

### DIFF
--- a/src/components/colorbuttons/ColorButton.style.ts
+++ b/src/components/colorbuttons/ColorButton.style.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import { ColorKey, PrimaryKeys, SecondaryKeys } from '@/components/colorbuttons/ColorButton.types';
+
+interface StyledColorButtonProps {
+  backgroundColor: ColorKey;
+}
+
+export const StyledColorButton = styled.span<StyledColorButtonProps>`
+  display: inline-flex;
+  height: 1.5rem;
+  padding: 0.0625rem 0.5rem;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.5rem;
+  background-color: ${({ backgroundColor, theme }) => {
+    if (backgroundColor in theme.colors.primary) {
+      return theme.colors.primary[backgroundColor as PrimaryKeys];
+    }
+    return theme.colors.secondary[backgroundColor as SecondaryKeys];
+  }};
+  color: ${(props) => props.theme.colors.grayScale.black};
+  ${({ theme }) => theme.fonts.body.xsmall500};
+`;

--- a/src/components/colorbuttons/ColorButton.tsx
+++ b/src/components/colorbuttons/ColorButton.tsx
@@ -2,6 +2,18 @@ import React from 'react';
 import { StyledColorButton } from './ColorButton.style';
 import { ColorButtonProps } from './ColorButton.types';
 
+/**
+ * 배경색을 정할 수 있는 ColorButton 컴포넌트입니다.
+ *
+ * @param string label - 버튼 내부에 표시될 텍스트
+ * @param keyof theme.colors backgroundColor - 테마에서 사용할 색상 키
+ *
+ * @example
+ * <ColorButton label={"포장가능"} backgroundColor={"bl400"}/>
+ * <ColorButton label={"LIVE"} backgroundColor={"pk200"}/>
+ * <ColorButton label={"공연무대"} backgroundColor={"rd500"}/>
+ */
+
 const ColorButton: React.FC<ColorButtonProps> = ({ label, backgroundColor }) => {
   return <StyledColorButton backgroundColor={backgroundColor}>{label}</StyledColorButton>;
 };

--- a/src/components/colorbuttons/ColorButton.tsx
+++ b/src/components/colorbuttons/ColorButton.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { StyledColorButton } from './ColorButton.style';
+import { ColorButtonProps } from './ColorButton.types';
+
+const ColorButton: React.FC<ColorButtonProps> = ({ label, backgroundColor }) => {
+  return <StyledColorButton backgroundColor={backgroundColor}>{label}</StyledColorButton>;
+};
+
+export default ColorButton;

--- a/src/components/colorbuttons/ColorButton.types.ts
+++ b/src/components/colorbuttons/ColorButton.types.ts
@@ -1,0 +1,14 @@
+import { DefaultTheme } from 'styled-components';
+
+export type PrimaryKeys = keyof DefaultTheme['colors']['primary'];
+export type SecondaryKeys = keyof DefaultTheme['colors']['secondary'];
+export type ColorKey = PrimaryKeys | SecondaryKeys;
+
+/**
+ * 받은 색깔 props에 따라 primary 색깔과 secondary 색깔을 구분하기 위한 타입'
+ */
+
+export interface ColorButtonProps {
+  label: string;
+  backgroundColor: ColorKey;
+}

--- a/src/components/colorbuttons/ColorButton.types.ts
+++ b/src/components/colorbuttons/ColorButton.types.ts
@@ -1,14 +1,32 @@
 import { DefaultTheme } from 'styled-components';
 
+/**
+ * 테마의 primary 컬러 키 타입
+ */
 export type PrimaryKeys = keyof DefaultTheme['colors']['primary'];
+
+/**
+ * 테마의 secondary 컬러 키 타입
+ */
 export type SecondaryKeys = keyof DefaultTheme['colors']['secondary'];
-export type ColorKey = PrimaryKeys | SecondaryKeys;
 
 /**
  * 받은 색깔 props에 따라 primary 색깔과 secondary 색깔을 구분하기 위한 타입'
  */
+export type ColorKey = PrimaryKeys | SecondaryKeys;
 
+/**
+ * TextBadge 컴포넌트의 Props 타입
+ */
 export interface ColorButtonProps {
+  /**
+   * 뱃지에 표시할 텍스트
+   */
   label: string;
+
+  /**
+   * 배경색으로 사용할 색상 키
+   * primary 또는 secondary 컬러에서 선택 가능
+   */
   backgroundColor: ColorKey;
 }

--- a/src/components/colorbuttons/index.ts
+++ b/src/components/colorbuttons/index.ts
@@ -1,0 +1,1 @@
+export { default as ColorButton } from './ColorButton';

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -20,6 +20,8 @@ const colors = {
   secondary: {
     pk200: '#FBA7FD',
     ye200: '#F9F79F',
+    rd500: '#F55353',
+    gr500: '#45E02A',
   },
   grayScale: {
     white: '#FAFAFA',


### PR DESCRIPTION
## 🔥 PR 제목  

[공통 컴포넌트] ColorButton

## 📌 작업 내용  

- 공통 버튼 ColorButton 컴포넌트 구현

- label, color 2가지 props 전달 할 수 있음
- label(string): 버튼에 들어갈 문구
- color: 배경색(bl400, pk200, rd500 등) 입력

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
![image](https://github.com/user-attachments/assets/6a88e8e1-e0f9-4457-a467-73dbb14c537c)

## 🚀 테스트 방법  

<ColorButton label={"포장가능"} backgroundColor={"bl400"}/>
<ColorButton label={"LIVE"} backgroundColor={"pk200"}/>
<ColorButton label={"공연무대"} backgroundColor={"rd500"}/>

## 💡 추가 논의할 사항  
배경색이랑 문구는 필수라 생각해서 입력 안했을 때 기본 상태 안 넣었는데 필요할까요??

## 🙏 리뷰어에게 한마디  