### PR TITLE
fix: bluebutton 폰트 추가

### DIFF
--- a/src/components/bluebuttons/BlueButton.style.ts
+++ b/src/components/bluebuttons/BlueButton.style.ts
@@ -8,13 +8,12 @@ export const StyledButton = styled.button<StyledButtonProps>`
   border: none;
   color: ${({ theme }) => theme.colors.grayScale.white};
   white-space: nowrap;
-  margin-bottom: 1rem;
   cursor: pointer;
-  padding: ${({ size }) => (size === 'small' ? '0.25rem 1rem' : '0.5rem 1.25rem')};
-  width: ${({ size }) => (size === 'small' ? '7.5rem' : '15rem')};
-  border-radius: ${({ size }) => (size === 'small' ? '0.5rem' : '0.75rem')};
-  ${({ size, theme }) => {
-    switch (size) {
+  padding: ${({ $size }) => ($size === 'small' ? '0.25rem 1rem' : '0.5rem 1.25rem')};
+  width: ${({ $size }) => ($size === 'small' ? '7.5rem' : '15rem')};
+  border-radius: ${({ $size }) => ($size === 'small' ? '0.5rem' : '0.75rem')};
+  ${({ $size, theme }) => {
+    switch ($size) {
       case 'large-header':
         return theme.fonts.header.h4;
       case 'large':
@@ -30,4 +29,8 @@ export const StyledButton = styled.button<StyledButtonProps>`
     background-color: ${({ theme }) => theme.colors.grayScale.gy700};
     cursor: not-allowed;
   }
+
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
 `;

--- a/src/components/bluebuttons/BlueButton.style.ts
+++ b/src/components/bluebuttons/BlueButton.style.ts
@@ -5,17 +5,29 @@ export const StyledButton = styled.button<StyledButtonProps>`
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: ${({ $isBigger }) => ($isBigger ? '0.5rem 1.25rem' : '0.25rem 1rem')};
-  width: ${({ $isBigger }) => ($isBigger ? '15rem' : '7.5rem')};
   border: none;
-  border-radius: ${({ $isBigger }) => ($isBigger ? '0.75rem' : '0.5rem')};
-  background-color: ${({ theme }) => theme.colors.primary.bl400};
-  ${({ $isBigger, theme }) => ($isBigger ? theme.fonts.body.medium500 : theme.fonts.body.small500)};
-  color: ${(props) => props.theme.colors.grayScale.white};
+  color: ${({ theme }) => theme.colors.grayScale.white};
   white-space: nowrap;
   margin-bottom: 1rem;
+  cursor: pointer;
+  padding: ${({ size }) => (size === 'small' ? '0.25rem 1rem' : '0.5rem 1.25rem')};
+  width: ${({ size }) => (size === 'small' ? '7.5rem' : '15rem')};
+  border-radius: ${({ size }) => (size === 'small' ? '0.5rem' : '0.75rem')};
+  ${({ size, theme }) => {
+    switch (size) {
+      case 'large-header':
+        return theme.fonts.header.h4;
+      case 'large':
+        return theme.fonts.body.medium500;
+      case 'small':
+      default:
+        return theme.fonts.body.small500;
+    }
+  }}
+  background-color: ${({ theme }) => theme.colors.primary.bl400};
 
   &:disabled {
     background-color: ${({ theme }) => theme.colors.grayScale.gy700};
+    cursor: not-allowed;
   }
 `;

--- a/src/components/bluebuttons/BlueButton.tsx
+++ b/src/components/bluebuttons/BlueButton.tsx
@@ -32,7 +32,7 @@ const BlueButton: React.FC<BlueButtonProps> = ({
   };
 
   return (
-    <StyledButton size={size} disabled={disabled} onClick={handleClick}>
+    <StyledButton $size={size} disabled={disabled} onClick={handleClick}>
       {label}
     </StyledButton>
   );

--- a/src/components/bluebuttons/BlueButton.tsx
+++ b/src/components/bluebuttons/BlueButton.tsx
@@ -4,28 +4,25 @@ import { BlueButtonProps } from './BlueButton.types';
 /**
  * 디자인 시스템 기반의 공통 BlueButton 컴포넌트입니다.
  * 사용자 정의 텍스트(label)를 표시하며, 클릭 시 onClick 함수를 실행합니다.
- * `isBigger` 값에 따라 스타일(폰트, 패딩, 테두리)이 달라집니다.
+ * `size` 값에 따라 스타일(폰트, 패딩, 너비, 테두리)이 달라집니다.
  *
- * @param string label - 버튼에 표시될 텍스트
+ * @param {string} label - 버튼에 표시될 텍스트
  * @param {boolean} [disabled=false] - 버튼 비활성화 여부
- * @param {boolean} [isBigger=true] - 버튼 크기 여부 (기본: true)
+ * @param {'small' | 'large' | 'large-header'} [size='large'] - 버튼 크기 및 스타일
  * @param {function} [onClick] - 버튼 클릭 시 실행할 콜백 함수
  *
  * @returns {React.ReactElement} BlueButton 컴포넌트
  *
  * @example
- * // 기본 사용 예시
- * <BlueButton label={"등록하기"} onClick={() => navigate('/booth')} />
- *
- * @example
- * // 작은 버튼 + 비활성화
- * <BlueButton label={"웨이팅 취소"} isBigger={false} onClick={() => navigate('/booth')} />
+ * <BlueButton label="로그인" size="large" onClick={handleClick} />
+      <BlueButton label="등록하러 가기" size="large-header" disabled={true} onClick={handleClick} />
+      <BlueButton label="등록하러 가기" size="large-header" onClick={handleClick} />
+      <BlueButton label="웨이팅 취소" size="small" onClick={handleClick} />
  */
-
 const BlueButton: React.FC<BlueButtonProps> = ({
   label,
   disabled = false,
-  isBigger = true,
+  size = 'large',
   onClick,
 }) => {
   const handleClick = () => {
@@ -35,7 +32,7 @@ const BlueButton: React.FC<BlueButtonProps> = ({
   };
 
   return (
-    <StyledButton $isBigger={isBigger} disabled={disabled} onClick={handleClick}>
+    <StyledButton size={size} disabled={disabled} onClick={handleClick}>
       {label}
     </StyledButton>
   );

--- a/src/components/bluebuttons/BlueButton.types.ts
+++ b/src/components/bluebuttons/BlueButton.types.ts
@@ -38,5 +38,5 @@ export interface BlueButtonProps {
  * 스타일 전용 Props
  */
 export interface StyledButtonProps {
-  size: BlueButtonSize;
+  $size: BlueButtonSize;
 }

--- a/src/components/bluebuttons/BlueButton.types.ts
+++ b/src/components/bluebuttons/BlueButton.types.ts
@@ -1,4 +1,12 @@
 /**
+ * 버튼 크기 타입
+ * - 'small': 작은 버튼 (폰트 small500)
+ * - 'large-body': 큰 버튼 (폰트 medium500)
+ * - 'large-header': 큰 버튼 (폰트 header.h4)
+ */
+export type BlueButtonSize = 'small' | 'large' | 'large-header';
+
+/**
  * 공통 BlueButton 컴포넌트의 Props
  */
 export interface BlueButtonProps {
@@ -9,26 +17,26 @@ export interface BlueButtonProps {
 
   /**
    * 버튼 비활성화 여부
-   * true일 경우 클릭이 비활성화되고 회색 스타일로 표시됨
    * @default false
    */
   disabled?: boolean;
 
   /**
-   * 버튼 크기 조정 여부
-   * true이면 기본 크기(더 큰 버튼), false이면 작아진 버튼
-   * @default true
+   * 버튼 사이즈 및 스타일
+   * @default 'large'
    */
-  isBigger?: boolean;
+  size?: BlueButtonSize;
 
   /**
    * 버튼 클릭 시 실행되는 함수
    * 예: 페이지 이동, 모달 열기 등 사용자 정의 동작
-   * @returns void
    */
   onClick?: () => void;
 }
 
+/**
+ * 스타일 전용 Props
+ */
 export interface StyledButtonProps {
-  $isBigger: boolean;
+  size: BlueButtonSize;
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,8 +1,20 @@
+import { BlueButton } from '@/components/bluebuttons';
+import { useNavigate } from 'react-router-dom';
+
 export default function Login() {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate('/main'); // 로그인 후 홈으로 이동
+  };
   return (
     <>
       {/**로그인 */}
       LOGIN
+      <BlueButton label="로그인" size="large" onClick={handleClick} />
+      <BlueButton label="등록하러 가기" size="large-header" disabled={true} onClick={handleClick} />
+      <BlueButton label="등록하러 가기" size="large-header" onClick={handleClick} />
+      <BlueButton label="웨이팅 취소" size="small" onClick={handleClick} />
     </>
   );
 }


### PR DESCRIPTION
## 🔥 PR 제목  

fix: bluebutton 폰트 추가
## 📌 작업 내용  

기존 버튼은 큰 버튼일 때 폰트 및 패딩 고정, 작은 버튼일 때 폰트 및 패딩 고정이었으나,
큰 버튼 일 때 폰트 경우의 수가 두 가지인 부분을 발견하여, 
isBigger 대신 size로 small, large, large-header 세가지 형태로 받을 수 있도록 설정.

small : 작은 버튼 , 폰트 s500
large: 큰 버튼, 폰트 medium500
large-header: 큰 버튼, 폰트 h4
## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
![image](https://github.com/user-attachments/assets/59fa9546-ffee-4c6d-b0e6-1abf4b132a8e)

## 🚀 테스트 방법  

<BlueButton label="로그인" size="large" onClick={handleClick} />
<BlueButton label="등록하러 가기" size="large-header" disabled={true} onClick={handleClick} />
<BlueButton label="등록하러 가기" size="large-header" onClick={handleClick} />
<BlueButton label="웨이팅 취소" size="small" onClick={handleClick} />

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  