### PR TITLE
fix: 분실물 메인페이지 뒤로가기 경로 설정

### DIFF
--- a/src/pages/main/Lost.tsx
+++ b/src/pages/main/Lost.tsx
@@ -27,6 +27,7 @@ export default function Lost() {
       <NavBar
         isBack={true}
         title="분실물 신고하기"
+        backPath={'/main'}
         isSearch={true}
         onSearchClick={() => navigate('/main/lost/search')}
       />


### PR DESCRIPTION
## 🔥 PR 제목  
fix: 분실물 메인페이지 뒤로가기 경로 설정

## 📌 작업 내용  
- 분실물 완료 페이지에서 분실물 페이지로 갔을 때 뒤로가기 버튼을 누르면 다시 완료 페이지로 가는 문제 발생
- 메인 페이지로 이동하게끔 설정

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  