### PR TITLE
[API] 공연 알림 API 연동

### DIFF
--- a/src/constants/performance/SingerInfo.ts
+++ b/src/constants/performance/SingerInfo.ts
@@ -5,6 +5,7 @@ export const performanceData = {
       id: '1',
       backgroundUrl: imageMap.Kino,
       singer: 'KINO',
+      fcm_singer: 'KINO',
       time: '17:00~17:30',
       description:
         '키노는 대한민국의 가수로 보이 그룹 펜타곤의 서브보컬, 메인댄서를 맡고 있다. 현재는 1인 기획사 NAKED를 설립하여 솔로 아티스트로서의 행보를 이어가고 있다.',
@@ -26,6 +27,7 @@ export const performanceData = {
       id: '2',
       backgroundUrl: imageMap.TenCm,
       singer: '10CM',
+      fcm_singer: '10CM',
       time: '20:00~20:30',
       description:
         "10CM는 홍대 버스킹에서 출발해 '아메리카노'로 이름을 알린 인디 뮤지션이다. 정규 앨범과 계절별 콘서트, 페스티벌 등 다양한 무대를 통해 꾸준히 활동 중이다. 특유의 어쿠스틱 사운드와 공감 가는 가사로 폭넓은 팬층을 확보하고 있다.",
@@ -51,6 +53,7 @@ export const performanceData = {
       id: '3',
       backgroundUrl: imageMap.FTISLAND,
       singer: 'FTISLAND',
+      fcm_singer: 'FTISLAND',
       time: '20:30~21:00',
       description:
         'FTISLAND는 2007년 데뷔한 K-록밴드로, 록 발라드를 대중화하며 주목받았다. 진정성 있는 밴드를 성장을 하였으며, 라이브 퍼포먼스에 강한 면모를 보이며 국내외 팬들에게 꾸준한 사랑을 받고 있다.',
@@ -76,6 +79,7 @@ export const performanceData = {
       id: '4',
       backgroundUrl: imageMap.Idle,
       singer: 'i-dle(아이들)',
+      fcm_singer: 'i-dle',
       time: '21:00~21:30',
       description:
         'i-dle은 대한민국의 다국적 걸그룹으로, 소연, 미연, 민니, 우기, 슈화로 구성된 5인조이다. 강렬하고 독창적인 콘셉트의 음악을 선보이며 글로벌 팬층을 형성하고 있다. 2025년, 팀명을 (여자)아이들에서 i-dle로 변경하며 경계 없는 정체성을 선언했다.',
@@ -103,6 +107,7 @@ export const performanceData = {
       id: '5',
       backgroundUrl: imageMap.Jackpot,
       singer: '잭팟(WING, Hellcat)',
+      fcm_singer: 'JACKPOT',
       time: '20:00~20:20',
       description:
         'WING, Hellcat이 결성한 태그 팀. 2016년부터 태그 팀 활동을 시작했으며, 세계 무대에서 활동하는 유일한 한국 태그 팀이다.',
@@ -128,6 +133,7 @@ export const performanceData = {
       id: '6',
       backgroundUrl: imageMap.Davichi,
       singer: '다비치',
+      fcm_singer: 'Davichi',
       time: '20:30~21:00',
       description:
         '다비치는 대한민국의 여성 듀오 보컬 그룹으로, 이해리와 강민경 두 멤버로 구성되어 있다. 뛰어난 가창력과 멤버 사이의 케미로 현역으로 활동하는 국내 여성 듀오 중 가장 최장수를 달리고 있는 그룹이다.',
@@ -153,6 +159,7 @@ export const performanceData = {
       id: '7',
       backgroundUrl: imageMap.Highlight,
       singer: '하이라이트',
+      fcm_singer: 'Hilight',
       time: '21:00~21:30',
       description:
         '하이라이트는 대한민국의 4인조 남성 아이돌 그룹으로, 2009년에 데뷔한 그룹 비스트의 멤버들이 설립한 새로운 소속사로 둥지를 틀면서 하이라이트라는 이름을 사용하게 되었다.',
@@ -180,6 +187,7 @@ export const performanceData = {
       id: '8',
       backgroundUrl: imageMap.Ifeye,
       singer: 'ifeye',
+      fcm_singer: 'IFEYE',
       time: '18:00~18:30',
       description:
         'ifeye는 대한민국의 신예 여성 아티스트로, 실험적인 사운드와 독창적인 음악 세계를 선보이며 주목받고 있다. 일렉트로닉과 인디 팝을 중심으로 한 독특한 음악 스타일은 기존의 틀에서 벗어난 새로운 흐름을 보여주며, 감각적인 비주얼 아트와 함께 자신만의 브랜드를 구축해가고 있다.',
@@ -201,6 +209,7 @@ export const performanceData = {
       id: '9',
       backgroundUrl: imageMap.Chungha,
       singer: '청하',
+      fcm_singer: 'Chungha',
       time: '19:45~20:15',
       description:
         '청하는 대한민국의 솔로 가수이자, 프로젝트 걸그룹 I.O.I 출신이다. 탄탄한 댄스 실력과 유려한 보컬, 뛰어난 무대 장악력을 겸비한 올라운더로, K-pop 3세대 여성 솔로 아티스트를 대표하는 인물로 자리매김했다.',
@@ -226,6 +235,7 @@ export const performanceData = {
       id: '10',
       backgroundUrl: imageMap.YB,
       singer: 'YB',
+      fcm_singer: 'YB',
       time: '20:15~21:15',
       description:
         'YB는 윤도현을 중심으로 1997년 정식 데뷔한 대한민국의 대표 록 밴드로, 베이스 박태희, 기타 허준, 드럼 김진원과 함께 활동 중이다. 2002년 월드컵 응원가 ‘오 필승 코리아’로 대중적인 인기를 얻으며 ‘국민 밴드’로 자리매김했다. 이후 다양한 방송 활동과 사회적 메시지를 담은 음악을 통해 대중성과 음악성을 동시에 인정받으며 꾸준히 활동을 이어오고 있다.',
@@ -251,6 +261,7 @@ export const performanceData = {
       id: '11',
       backgroundUrl: imageMap.DJ,
       singer: 'DJ주디',
+      fcm_singer: 'DJ Judy',
       time: '21:15~21:45',
       description:
         'DJ주디는 대한민국의 DJ 겸 음악 프로듀서이다. 다양한 일렉트로닉 장르를 기반으로 개성 있는 사운드를 선보이며 클럽과 페스티벌 등에서 활발히 활동 중이다. ',

--- a/src/features/alarm/components/Alert.tsx
+++ b/src/features/alarm/components/Alert.tsx
@@ -2,6 +2,7 @@ import * as S from './Alert.styles';
 import AlertIcon from '@/assets/icons/alert.svg?react';
 import AlertFillIcon from '@/assets/icons/alert-filled.svg?react';
 import { useAlarmStore } from '../stores/useAlarmStore';
+import { registerArtistAlarm } from '@/services/alarm';
 /**
  * @component OpenAlert
  * @description 오픈 알림 버튼
@@ -45,11 +46,22 @@ export function OpenAlert() {
 export function PerformanceAlert({ id }: { id: string }) {
   const { getPerformanceAlarm, setPerformanceAlarm } = useAlarmStore();
   const isAlarm = getPerformanceAlarm(id);
+
+  const handleClick = async () => {
+    const next = !isAlarm;
+    try {
+      if (next) {
+        const result = await registerArtistAlarm(id);
+        console.log('알림 등록 성공', result);
+      }
+    } catch (err) {
+      console.error('알림 등록 실패', err);
+    }
+    setPerformanceAlarm(id, next);
+  };
+
   return (
-    <S.Button
-      whileTap={{ scale: 0.9, backgroundColor: '#212526' }}
-      onClick={() => setPerformanceAlarm(id, !isAlarm)}
-    >
+    <S.Button whileTap={{ scale: 0.9, backgroundColor: '#212526' }} onClick={() => handleClick()}>
       {isAlarm ? (
         <AlertFillIcon width={'1rem'} height={'1rem'} />
       ) : (
@@ -73,6 +85,7 @@ export function PerformanceAlert({ id }: { id: string }) {
 export function PerformanceIconAlert({ id }: { id: string }) {
   const { getPerformanceAlarm, setPerformanceAlarm } = useAlarmStore();
   const isAlarm = getPerformanceAlarm(id);
+
   return (
     <S.IconButton whileTap={{ scale: 0.9 }} onClick={() => setPerformanceAlarm(id, !isAlarm)}>
       {isAlarm ? (

--- a/src/features/alarm/components/Alert.tsx
+++ b/src/features/alarm/components/Alert.tsx
@@ -51,8 +51,7 @@ export function PerformanceAlert({ id }: { id: string }) {
     const next = !isAlarm;
     try {
       if (next) {
-        const result = await registerArtistAlarm(id);
-        console.log('알림 등록 성공', result);
+        await registerArtistAlarm(id);
       }
     } catch (err) {
       console.error('알림 등록 실패', err);

--- a/src/features/alarm/stores/useAlarmStore.ts
+++ b/src/features/alarm/stores/useAlarmStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 interface AlarmStateType {
   boothAlarm: boolean;
@@ -17,12 +18,21 @@ interface AlarmActionType {
  * @param {AlarmActionType} actions 알림 액션 타입
  * @returns {AlarmStateType & AlarmActionType} 알림 상태 타입과 액션 타입을 반환
  */
-export const useAlarmStore = create<AlarmStateType & AlarmActionType>((set, get) => ({
-  boothAlarm: false,
-  performanceAlarm: [], // 공연 알림 목록 추가 시 default 값 변경
-  setBoothAlarm: (isAlarm) => set({ boothAlarm: isAlarm }),
-  setPerformanceAlarm: (id, isAlarm) =>
-    set((state) => ({ performanceAlarm: [...state.performanceAlarm, { id, isAlarm: isAlarm }] })),
-  getPerformanceAlarm: (id) =>
-    get().performanceAlarm.find((alarm) => alarm.id === id)?.isAlarm ?? false,
-}));
+export const useAlarmStore = create(
+  persist<AlarmStateType & AlarmActionType>(
+    (set, get) => ({
+      boothAlarm: false,
+      performanceAlarm: [], // 공연 알림 목록 추가 시 default 값 변경
+      setBoothAlarm: (isAlarm) => set({ boothAlarm: isAlarm }),
+      setPerformanceAlarm: (id, isAlarm) =>
+        set((state) => ({
+          performanceAlarm: [...state.performanceAlarm, { id, isAlarm: isAlarm }],
+        })),
+      getPerformanceAlarm: (id) =>
+        get().performanceAlarm.find((alarm) => alarm.id === id)?.isAlarm ?? false,
+    }),
+    {
+      name: 'alarm-storage', // 스토리지 이름
+    },
+  ),
+);

--- a/src/features/performance/Carousel.tsx
+++ b/src/features/performance/Carousel.tsx
@@ -132,7 +132,7 @@ export default function Carousel({ data }: CarouselProps) {
           <S.TimeText fade={textFade}>{currentSinger.time}</S.TimeText>
         </S.TimeBox>
         <S.AlertBox>
-          <PerformanceAlert id={currentSinger.singer} />
+          <PerformanceAlert id={currentSinger.fcm_singer} />
         </S.AlertBox>
       </S.SingerTimeWrap>
     </S.Container>

--- a/src/features/performance/Carousel.tsx
+++ b/src/features/performance/Carousel.tsx
@@ -132,7 +132,7 @@ export default function Carousel({ data }: CarouselProps) {
           <S.TimeText fade={textFade}>{currentSinger.time}</S.TimeText>
         </S.TimeBox>
         <S.AlertBox>
-          <PerformanceAlert id={currentSinger.id} />
+          <PerformanceAlert id={currentSinger.singer} />
         </S.AlertBox>
       </S.SingerTimeWrap>
     </S.Container>

--- a/src/features/performance/Carousel.types.ts
+++ b/src/features/performance/Carousel.types.ts
@@ -14,6 +14,7 @@ export type PerformanceItem = {
   id: string;
   backgroundUrl: string;
   singer: string;
+  fcm_singer: string;
   time: string;
   description: string;
   songList: { image: string; name: string }[];

--- a/src/services/alarm.ts
+++ b/src/services/alarm.ts
@@ -4,5 +4,15 @@ export const sendToken = async (token: string) => {
   const response = await axiosInstance.post('/fcm/token', {
     token: token,
   });
-  return response.data;
+  return response;
+};
+
+/**
+ * 아티스트 공연 시작 전 알림 신청
+ * @params {string} artistName - 아티스트 이름
+ */
+export const registerArtistAlarm = async (artistName: string) => {
+  return await axiosInstance.post('/concert/alarm', null, {
+    params: { artistName: encodeURIComponent(artistName) },
+  });
 };

--- a/src/services/alarm.ts
+++ b/src/services/alarm.ts
@@ -12,7 +12,5 @@ export const sendToken = async (token: string) => {
  * @params {string} artistName - 아티스트 이름
  */
 export const registerArtistAlarm = async (artistName: string) => {
-  return await axiosInstance.post('/concert/alarm', null, {
-    params: { artistName: encodeURIComponent(artistName) },
-  });
+  return await axiosInstance.post(`/concert/${encodeURIComponent(artistName)}/alarm`);
 };


### PR DESCRIPTION
## 🔥 PR 제목  
- [API] 공연 알림 API 연동

## 📌 작업 내용  
### 추가
- API 로직 추가 
- singerInfo에 fcm_singer 추가 (DB 쿼리에 날리는 이름이랑 동일해야 하는 이슈)

### 수정
- persist 이용해서 alarm 상태 저장 (새로고침해도 유지)
- sendToken의 return 값 response.data -> response 로 변경 (axiosInstance에서 error.response.status로 판단)
- 현재 response 값이 다음과 같이 있어서 reponse 자체를 넘겨주는 게 맞는 것 같아서 수정했습니다.
  "data: 'Save FCM Token Successfully', status: 200, statusText: '', headers: AxiosHeaders, config: {…}, …}"

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

https://github.com/user-attachments/assets/f80e5d8d-d82a-45cb-8c86-ae129ff9da64


## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  