### PR TITLE
설치 유도 기능 추가

### DIFF
--- a/src/features/main/components/user/AppInstallPrompt.styles.ts
+++ b/src/features/main/components/user/AppInstallPrompt.styles.ts
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
+import CloseBtn from '@/assets/icons/nrk_close.svg?react';
+import HelpIcon from '@/assets/icons/nrk_help.svg?react';
+
+export const ModalOverlay = styled(motion.div)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 100;
+  background-color: rgb(0 0 0 / 70%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  backdrop-filter: blur(2px);
+`;
+
+export const ModalWrapper = styled(motion.div)`
+  min-width: 20.9375rem;
+  background-color: ${(props) => props.theme.colors.grayScale.black};
+  border-radius: 0.75rem;
+  margin-top: -6.625rem;
+`;
+
+export const ModalTab = styled.div`
+  height: 3rem;
+  border-bottom: 0.6px solid ${(props) => props.theme.colors.grayScale.gy900};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.75rem;
+  position: relative;
+`;
+
+export const ModalTitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+`;
+
+export const ModalTitleText = styled.span`
+  ${(props) => props.theme.fonts.header.h4};
+  color: ${(props) => props.theme.colors.grayScale.white};
+`;
+
+export const Help = styled(HelpIcon)``;
+
+export const ModalCloseBtn = styled(CloseBtn)`
+  position: absolute;
+  right: 1rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+export const Content = styled.div`
+  padding: 1.25rem 0rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+`;
+
+export const ModalText = styled.span`
+  ${(props) => props.theme.fonts.body.medium500};
+  color: ${(props) => props.theme.colors.grayScale.white};
+  text-align: center;
+`;
+
+export const CancelButton = styled.button`
+  background-color: transparent;
+  border: none;
+  color: ${(props) => props.theme.colors.grayScale.gy500};
+  ${(props) => props.theme.fonts.body.xsmall500};
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-skip-ink: auto;
+  text-decoration-thickness: auto;
+  text-underline-offset: auto;
+`;

--- a/src/features/main/components/user/AppInstallPrompt.tsx
+++ b/src/features/main/components/user/AppInstallPrompt.tsx
@@ -1,0 +1,120 @@
+import { BeforeInstallPromptEvent } from '@/types/window';
+import { Fragment, useEffect, useState } from 'react';
+import * as S from './AppInstallPrompt.styles';
+import { easeOut } from 'framer-motion';
+import { BlueButton } from '@/components/bluebuttons';
+
+const defaultBeforeInstallPromptEvent: BeforeInstallPromptEvent = {
+  platforms: [],
+  userChoice: Promise.resolve({ outcome: 'dismissed', platform: '' }),
+  prompt: () => Promise.resolve(),
+  preventDefault: () => {},
+};
+
+const isIOSPromptActive = () => {
+  const isActive = JSON.parse(localStorage.getItem('iosInstalled') || 'true');
+
+  if (isActive) {
+    return defaultBeforeInstallPromptEvent;
+  }
+
+  return null;
+};
+
+export default function AppInstallPrompt() {
+  const isDeviceIOS = /iPad|iPhone|iPod/.test(window.navigator.userAgent);
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(
+    isDeviceIOS ? isIOSPromptActive() : null,
+  );
+
+  const handleInstallClick = () => {
+    if (deferredPrompt) {
+      deferredPrompt.prompt();
+
+      deferredPrompt.userChoice.then(() => {
+        setDeferredPrompt(null);
+      });
+    }
+  };
+
+  const handleCancelClick = () => {
+    localStorage.setItem('iosInstalled', 'false');
+    setDeferredPrompt(null);
+  };
+
+  const handleBeforeInstallPrompt = (event: BeforeInstallPromptEvent) => {
+    event.preventDefault();
+    setDeferredPrompt(event);
+  };
+
+  useEffect(() => {
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    };
+  }, []);
+  return (
+    <Fragment>
+      {deferredPrompt && (
+        <AppInstallPromptModal
+          handleInstallClick={handleInstallClick}
+          handleCancelClick={handleCancelClick}
+          platform={isDeviceIOS ? 'ios' : 'android'}
+        />
+      )}
+    </Fragment>
+  );
+}
+
+function AppInstallPromptModal({
+  handleInstallClick,
+  handleCancelClick,
+  platform,
+}: {
+  handleInstallClick: () => void;
+  handleCancelClick: () => void;
+  platform: 'ios' | 'android';
+}) {
+  return (
+    <S.ModalOverlay
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.25 }}
+    >
+      <S.ModalWrapper
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        exit={{ scale: 0.8 }}
+        transition={{ delay: 0.2, duration: 0.2, ease: easeOut }}
+      >
+        <S.ModalTab>
+          <S.ModalTitle>
+            {<S.Help fill="#e9e9ea" width={18} height={18} />}
+            <S.ModalTitleText>홈 화면 추가하기</S.ModalTitleText>
+          </S.ModalTitle>
+          <S.ModalCloseBtn onClick={handleCancelClick} fill="#fafafa" width={18} height={18} />
+        </S.ModalTab>
+        <S.Content>
+          {platform === 'ios' ? (
+            <S.ModalText>
+              {' '}
+              사파리 브라우저신가요?
+              <br /> 공유하기, 홈 화면 추가하기를 눌러주세요!
+            </S.ModalText>
+          ) : (
+            <S.ModalText>
+              홈 화면에 추가하면
+              <br /> 더 편리하게 HyLight를 즐길 수 있어요!
+            </S.ModalText>
+          )}
+          {platform === 'android' && (
+            <BlueButton onClick={handleInstallClick} label="홈 화면에 추가하기" />
+          )}
+          <S.CancelButton onClick={handleCancelClick}>불편해도 웹에서 이용하기</S.CancelButton>
+        </S.Content>
+      </S.ModalWrapper>
+    </S.ModalOverlay>
+  );
+}

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -8,6 +8,7 @@ import { Modal as ModalProvider } from '@/components/modal';
 import { useWaitingStore } from '@/features/waiting/stores/useWaitingStore';
 import { useEffect } from 'react';
 import { useAuthStore } from '@/stores/useAuthStore';
+import AppInstallPrompt from '@/features/main/components/user/AppInstallPrompt';
 
 /**
  * Layout component
@@ -22,6 +23,7 @@ export default function Layout() {
   }, [loadWaitings, isLoggined]);
   return (
     <S.Container>
+      <AppInstallPrompt />
       {isNav && <Nav />}
       <AnimatePresence mode="wait">
         <Main>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -139,14 +139,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    /**navigator.serviceWorker
+    navigator.serviceWorker
       .register('/sw.js')
       .then((registration) => {
         console.log('✅ PWA 서비스워커 등록 완료:', registration);
       })
       .catch((err) => {
         console.error('❌ PWA 서비스워커 등록 실패:', err);
-      });**/
+      });
     navigator.serviceWorker
       .register('/firebase-messaging-sw.js')
       .then((registration) => {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,15 @@
+export interface BeforeInstallPromptEvent {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+  preventDefault(): void;
+  prompt(): Promise<void>;
+}
+
+declare global {
+  interface WindowEventMap {
+    beforeinstallprompt: BeforeInstallPromptEvent;
+  }
+}


### PR DESCRIPTION
## 🔥 PR 제목  
설치 유도 기능 추가
## 📌 작업 내용  
PWA를 설치하지 않고 웹사이트로만 이용 중인 사용자에게 설치 유도 기능을 추가했습니다.
iOS와 Android 각각에 맞춰 설치 유도 처리가 분기되어 작동합니다.
## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
<img width="384" alt="스크린샷 2025-05-22 오전 11 21 05" src="https://github.com/user-attachments/assets/1db05ff5-01c5-4c4f-b9ff-88603bc6d05f" />

## 🚀 테스트 방법  
	1.	모바일 환경에서 웹사이트 접속
	2.	PWA 미설치 상태에서 설치 유도 메시지가 노출되는지 확인
	3.	설치 이후에는 동일 메시지가 다시 뜨지 않는지 확인
## 💡 추가 논의할 사항  
설치 유도 메시지의 디자인 및 노출 타이밍 관련해서 피드백 받으면 적용 예정입니다.
## 🙏 리뷰어에게 한마디  
PWA 설치율을 높이기 위한 첫 작업입니다. 코드 흐름이나 조건 분기 구조 위주로 봐주시면 감사하겠습니다!