### PR TITLE
main framer motion animate 제거

### DIFF
--- a/src/layout/main/Main.tsx
+++ b/src/layout/main/Main.tsx
@@ -1,17 +1,5 @@
 import * as S from './Main.styles';
-import { easeInOut } from 'framer-motion';
-import { useLocation } from 'react-router-dom';
 
 export default function Main({ children }: { children: React.ReactNode }) {
-  const locate = useLocation();
-  return (
-    <S.Main
-      key={locate.pathname}
-      initial={S.getAnimation('center').initial}
-      animate={S.getAnimation('center').animate}
-      transition={{ duration: 0.2, ease: easeInOut }}
-    >
-      {children}
-    </S.Main>
-  );
+  return <S.Main>{children}</S.Main>;
 }


### PR DESCRIPTION
## 🔥 PR 제목  
main framer motion animate 제거
## 📌 작업 내용  
메인 페이지(main)에 적용되어 있던 framer-motion의 animate 속성 제거
불필요한 애니메이션으로 인한 렌더링 지연 혹은 사용자 경험 저하를 방지
## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  
메인 페이지 접속 시 애니메이션 없이 바로 렌더링되는지 확인
레이아웃 깨짐이나 전환 오류가 없는지 점검
## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  