### PR TITLE
주점 실시간 웨이팅 카운트 api 연동

### DIFF
--- a/src/features/waiting/components/Waiting.tsx
+++ b/src/features/waiting/components/Waiting.tsx
@@ -5,13 +5,24 @@ import useModal from '@/hooks/useModal';
 import WaitingModal from '@/features/waiting/components/WaitingModal';
 import { useRef } from 'react';
 import { useWaitingStore } from '@/features/waiting/stores/useWaitingStore';
+import { useLikeStore } from '@/features/like/stores/useLikeStore';
 
 export default function Waiting({ id }: { id: number }) {
   const WaitingModalWithId = WaitingModal as React.ComponentType<{ id: number; title: string }>;
   const { open } = useModal(WaitingModalWithId);
   const waitings = useWaitingStore((state) => state.waitings);
+  const likes = useLikeStore((state) => state.likes).find((like) => like.id === id);
+  const fetchWaitingCounts = useLikeStore((state) => state.fetchWaitingCounts);
   const hasPubId = useWaitingStore((state) => state.hasPubId(id));
   const waitingRef = useRef<HTMLDivElement>(null);
+  const handleRefresh = async () => {
+    try {
+      await fetchWaitingCounts();
+    } catch (error) {
+      console.error('Error fetching waiting counts:', error);
+    }
+  };
+  console.log(likes?.waitingCount);
   return (
     <S.Container ref={waitingRef}>
       <S.HeaderText>대기 현황</S.HeaderText>
@@ -19,11 +30,15 @@ export default function Waiting({ id }: { id: number }) {
       <S.TextSection>
         <S.TextBtnFrame>
           <S.MediumText>
-            실시간 웨이팅 <S.MediumText $isBlue>N</S.MediumText>팀
+            실시간 웨이팅{' '}
+            <S.MediumText $isBlue>
+              {likes?.waitingCount === undefined ? 'N' : likes.waitingCount}
+            </S.MediumText>
+            팀
           </S.MediumText>
-          <RefreshButton onClick={() => {}} />
+          <RefreshButton onClick={handleRefresh} />
         </S.TextBtnFrame>
-        <S.SmallText>웨이팅 가능 시간 : 금일 00:00 ~ 00:00</S.SmallText>
+        <S.SmallText>웨이팅 가능 시간 : 금일 18:00 ~ 23:00</S.SmallText>
       </S.TextSection>
       <S.ButtonFrame>
         <S.Button

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -19,11 +19,12 @@ export default function Layout() {
   const isLoggined = useAuthStore((state) => state.isLoggedIn);
   const loadWaitings = useWaitingStore((state) => state.loadWaitings);
   const loadlikes = useLikeStore((state) => state.initLikes);
-
+  const fetchWaitingCounts = useLikeStore((state) => state.fetchWaitingCounts);
   useEffect(() => {
     loadlikes();
+    fetchWaitingCounts();
     if (isLoggined) loadWaitings();
-  }, [loadWaitings, isLoggined, loadlikes]);
+  }, [loadWaitings, isLoggined, loadlikes, fetchWaitingCounts]);
   return (
     <S.Container>
       {isNav && <Nav />}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,7 +26,9 @@ import {
   LostFail,
 } from '@/pages';
 import Layout from '@/layout';
+import 'firebase/compat/app';
 import '@/services/fcm/foregroundMessage';
+
 if (window.Kakao && !window.Kakao.isInitialized()) {
   window.Kakao.init('b3f17a02c1f339facee6125f903e309e');
 }

--- a/src/services/waiting/waiting.ts
+++ b/src/services/waiting/waiting.ts
@@ -22,3 +22,8 @@ export const deleteWaitings = async (id: number) => {
   const response = await axiosInstance.delete(`/api/waitings?id=${id}`);
   return response;
 };
+
+export const getWaitingCount = async () => {
+  const response = await axiosInstance.get('/api/pubs/waiting-count');
+  return response;
+};

--- a/src/types/like.type.ts
+++ b/src/types/like.type.ts
@@ -1,7 +1,9 @@
 export interface LikeType {
   id: number;
   likeCount: number;
+  name?: string;
   prevRank?: number;
   currentRank?: number;
   updateCount: number;
+  waitingCount?: number;
 }


### PR DESCRIPTION
## 🔥 PR 제목  
주점 실시간 웨이팅 카운트 api 연동
## 📌 작업 내용  
waiting Count api -> like indexed db 추가 연동 방식 구현
## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  