### PR TITLE
fix: 블루버튼 사이즈 수정

### DIFF
--- a/src/components/bluebuttons/BlueButton.style.ts
+++ b/src/components/bluebuttons/BlueButton.style.ts
@@ -24,20 +24,20 @@ export const StyledButton = styled.button<StyledButtonProps>`
     switch ($size) {
       case 'small':
         return '7.5rem';
-      case 'larger':
-        return '20.9375rem';
-      default:
+      case 'large':
         return '15rem';
+      default:
+        return '20.9375rem';
     }
   }};
   ${({ $size, theme }) => {
     switch ($size) {
+      case 'small':
+        return theme.fonts.body.small500;
       case 'large-header':
         return theme.fonts.header.h4;
-      case 'large':
-        return theme.fonts.body.medium500;
       default:
-        return theme.fonts.body.small500;
+        return theme.fonts.body.medium500;
     }
   }}
   background-color: ${({ theme }) => theme.colors.primary.bl400};

--- a/src/components/bluebuttons/BlueButton.types.ts
+++ b/src/components/bluebuttons/BlueButton.types.ts
@@ -1,8 +1,9 @@
 /**
  * 버튼 크기 타입
- * - 'small': 작은 버튼 (폰트 small500)
- * - 'large-body': 큰 버튼 (폰트 medium500)
- * - 'large-header': 큰 버튼 (폰트 header.h4)
+ * - 'small': 7.5rem 버튼 (폰트 small500)
+ * - 'large': 15rem 버튼 (폰트 medium500)
+ * - 'large-header': 20rem 버튼 (폰트 header.h4)
+ * - 'larger': 20 rem 버튼 (폰트 medium500)
  */
 export type BlueButtonSize = 'small' | 'large' | 'large-header' | 'larger';
 


### PR DESCRIPTION
## 🔥 PR 제목  

블루버튼 사이즈 수정
## 📌 작업 내용  

 버튼 크기 타입
 - 'small': 7.5rem 버튼 (폰트 small500)
 - 'large': 15rem 버튼 (폰트 medium500)
 - 'large-header': 20rem 버튼 (폰트 header.h4)
 - 'larger': 20 rem 버튼 (폰트 medium500)
 - 
## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  