### PR TITLE
[수정사항] 주점 메뉴 오타 수정

### DIFF
--- a/src/constants/booth/booth.ts
+++ b/src/constants/booth/booth.ts
@@ -1261,9 +1261,9 @@ export const BOOTH_LIST = [
     menu: {
       main: [
         {
-          name: '대패숙죽볶음',
+          name: '대패숙주볶음',
           describtion: '지금까지 이런 맛은 없었다. 이것은 대패인가 숙주인가 "대패숙주볶음"',
-          price: '22,900 원',
+          price: '18,900 원',
         },
         {
           name: '불막창',
@@ -1704,14 +1704,14 @@ export const BOOTH_LIST = [
           price: '4,900 원',
         },
         {
-          name: '물',
-          describtion: '갈아만든배 / 콜라 / 제로콜라 / 사이다',
-          price: '1,000 원',
+          name: '음료수',
+          describtion: '제로콜라 / 사이다',
+          price: '2,000 원',
         },
         {
-          name: '음료수',
+          name: '물',
           describtion: '',
-          price: '2,000 원',
+          price: '1,000 원',
         },
       ],
     },


### PR DESCRIPTION
## 🔥 PR 제목  
- [수정사항] 주점 메뉴 오타 수정

## 📌 작업 내용  
- 차반 음료수 (제로콜라 / 사이다)
- 스융 대패숙주볶음 (18,900원)

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 테스트 완료  
- [x] 필요한 경우 문서를 업데이트했는지 확인  
- [x] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
<img width="416" alt="스크린샷 2025-05-26 오후 1 10 43" src="https://github.com/user-attachments/assets/253acd08-0bd7-4e16-9a9a-f582e2658e60" />
<img width="367" alt="스크린샷 2025-05-26 오후 1 10 55" src="https://github.com/user-attachments/assets/593afe54-9526-4917-903e-51889c57259f" />

## 🚀 테스트 방법  
- 차반, 스융 들어가서 잘 반영되었는지 확인

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  