### PR TITLE
[수정사항] tab-nav 가로 길이 동일

### DIFF
--- a/src/components/tab-nav/TabNav.styles.ts
+++ b/src/components/tab-nav/TabNav.styles.ts
@@ -12,12 +12,12 @@ export const Nav = styled.nav`
 `;
 
 export const List = styled.ul`
-  display: grid;
-  grid-auto-flow: column;
+  display: flex;
   gap: 0.5rem;
 `;
 
 export const Item = styled(motion.li)<{ $current: boolean }>`
+  flex: 1;
   color: ${(props) =>
     props.$current ? props.theme.colors.grayScale.gy50 : props.theme.colors.grayScale.gy700};
   ${(props) => props.theme.fonts.header.h4};


### PR DESCRIPTION
## 🔥 PR 제목  
- [수정사항] tab-nav 가로 길이 동일

## 📌 작업 내용  
- tab-nav 가로 길이 동일하게 맞췄습니다 (flex: 1 이용)

## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  
<img width="411" alt="스크린샷 2025-05-26 오후 3 27 12" src="https://github.com/user-attachments/assets/afee7aa4-cfe0-4d92-bdda-9aaf729890d4" />

<img width="420" alt="스크린샷 2025-05-26 오후 3 27 28" src="https://github.com/user-attachments/assets/15d12829-7ef1-4c70-b0a9-06e4472cd8c2" />

## 🚀 테스트 방법  
- 타임 테이블, 주점 페이지의 Tab-Nav 가로 길이가 동일한지 확인

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  