### PR TITLE
공연 이벤트 수정 및 한국시간 기준 이벤트 출력

### DIFF
--- a/src/constants/main/MainEvent.ts
+++ b/src/constants/main/MainEvent.ts
@@ -71,7 +71,7 @@ export const MainEventData: EventCardDate = {
     {
       id: '5',
       tags: [{ color: 'or100', text: '공연무대' }],
-      title: 'HIDDEN ARTIST',
+      title: 'NCT 마크',
       startTime: '18:15',
       endTime: '18:45',
       location: '공연장',

--- a/src/features/main/components/carousels/EventCarousels.tsx
+++ b/src/features/main/components/carousels/EventCarousels.tsx
@@ -31,7 +31,8 @@ export default function EventCarousels() {
   };
 
   const now = new Date();
-  const todayStr = now.toISOString().split('T')[0];
+  const korea = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const todayStr = korea.toISOString().split('T')[0];
   const todayEvents: EventCardData[] = MainEventData[todayStr] ?? [];
 
   const nightOn = (card: EventCardData, now: Date): boolean => {


### PR DESCRIPTION
## 🔥 PR 제목  

## 📌 작업 내용  
- UTC 기준 시간 -> 한국시간 기준으로 수정하여 오전 9시에 업데이트될 이벤트를 자정 기준으로 변경
- 히든아티스트 수정
## ✅ 체크리스트  
- [ ] 코드가 정상적으로 동작하는지 테스트 완료  
- [ ] 필요한 경우 문서를 업데이트했는지 확인  
- [ ] 코드 리뷰어가 이해할 수 있도록 설명을 추가했는지 확인  

## 📸 스크린샷 (선택)  

## 🚀 테스트 방법  

## 💡 추가 논의할 사항  

## 🙏 리뷰어에게 한마디  